### PR TITLE
Fix for reserved keywords in struct members

### DIFF
--- a/jsonx.d
+++ b/jsonx.d
@@ -122,6 +122,36 @@ void skipWhite(R)(ref R input) if (isInputCharRange!R) {
     }
 }
 
+void fixReservedKeyword(ref string key) {
+    switch ( key ) {
+    default: break;
+    case "abstract": case "alias": case "align": case "asm": case "assert":
+    case "auto": case "body": case "bool": case "break": case "byte":
+    case "case": case "cast": case "catch": case "cdouble": case "cent":
+    case "cfloat": case "char": case "class": case "const": case "continue":
+    case "creal": case "dchar": case "debug": case "default": case "delegate":
+    case "deprecated": case "do": case "double": case "else": case "enum":
+    case "export": case "extern": case "false": case "final": case "finally":
+    case "float": case "for": case "foreach": case "foreach_reverse":
+    case "function": case "goto": case "idouble": case "if": case "ifloat":
+    case "immutable": case "import": case "in": case "inout": case "int":
+    case "interface": case "invariant": case "ireal": case "is": case "lazy":
+    case "long": case "mixin": case "module": case "new": case "nothrow":
+    case "null": case "out": case "override": case "package": case "pragma":
+    case "private": case "protected": case "public": case "pure": case "real":
+    case "ref": case "return": case "scope": case "shared": case "short":
+    case "static": case "struct": case "super": case "switch":
+    case "synchronized": case "template": case "this": case "throw":
+    case "true": case "try": case "typeid": case "typeof": case "ubyte":
+    case "ucent": case "uint": case "ulong": case "union": case "unittest":
+    case "ushort": case "version": case "void": case "wchar":
+    case "while": case "with":
+      key = "_" ~ key;
+    break;
+    }
+}
+
+
 /* Encode JsonValue. Not able to encode all variants, but should be able to round-trip
  * variants created from jsonDecode. */
 void jsonEncode_impl(T : JsonValue, A)(T v, ref A app) {
@@ -337,6 +367,8 @@ T jsonDecode_impl(T, R)(ref R input)
             auto key = jsonDecode_impl!(aaKeyType!T)(input);
         } else {
             auto key = jsonDecode_impl!string(input);
+            /* Check if it's a reserved keyword */
+            fixReservedKeyword(key);
         }
 
         skipWhite(input);
@@ -841,4 +873,13 @@ unittest{
     assert('x' !in aa);
     assert(aa['a'] == 1);
     assert(aa['b'] == 2);
+}
+unittest{
+    // Reserved keywords in structs
+    struct KeywordTest {
+      string _version, _module;
+    }
+    auto test = jsonDecode!KeywordTest(`{"version":"1.0", "module":"json"}`);
+    assert(test._version == "1.0");
+    assert(test._module  == "json");
 }


### PR DESCRIPTION
Fixes problem where JSON variables were not able to be to set D members if they had the same name as a reserved D keyword. For example, "module" and "version" are now aliased to "_version" and "_module" for struct and class members. This does not affect associative arrays.
From issue https://github.com/gianm/d-json/issues/4
By the way, this only compiles if merged with the Dv2.074 fixes from pull request https://github.com/gianm/d-json/pull/3